### PR TITLE
Add support for IE8

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
 module.exports = function castArray (value) {
-  return Array.isArray(value) ? value : [value]
+  var isArray = Object.prototype.toString.call(value) === '[object Array]'
+  return isArray ? value : [value]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cast-array",
   "main": "index.js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Ensure a value is an array and wrap it if it is not an array",
   "license": "MIT",
   "repository": "bendrucker/cast-array",


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray), `Array.isArray` is not supported on IE8. This PR will replace the current implementation with a more wide-supported one (mentioned in the polyfill chapter of the MDN article).

I also bumped the version in `package.json` for your convenience.

I hope you have a great day! :smiley: 
